### PR TITLE
Add docker.sock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,5 @@ services:
       - HEALTH_SERVER_ADDRESS=127.0.0.1:9999
       - TZ=America/Montreal
     restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Without access to the docker.sock it gives the error code: 
|`ERROR Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`