### PR TITLE
[Feature] Restart other containers when after an unhealthy one

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Restart your unhealthy containers safely
 
 1. Set labels on containers:
     - To restart containers if they go unhealthy, use the label `deunhealth.restart.on.unhealthy=true`
+    - To restart another container, when an unhealthy one is restarted by deunhealth, use the label `deunhealth.restart.with.unhealthy.container=<deunhealth-monitored container name>`
 
 1. You can update the image with `docker pull qmcgaw/deunhealth:latest` or use one of the [tags available](https://hub.docker.com/r/qmcgaw/deunhealth/tags). ⚠️ You might want to use tagged images since `latest` will likely break compatibility until we reach a `v1.0.0` release.
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -12,6 +12,7 @@ var _ Dockerer = (*Docker)(nil)
 type Dockerer interface {
 	UnhealthyGetter
 	UnhealthyStreamer
+	LinkedContainerGetter
 	ContainerRestarter
 	LabeledGetter
 }

--- a/internal/docker/name.go
+++ b/internal/docker/name.go
@@ -1,6 +1,8 @@
 package docker
 
 import (
+	"strings"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 )
@@ -9,7 +11,7 @@ func extractName(container types.Container) (name string) {
 	name = container.ID
 	for _, containerName := range container.Names {
 		if containerName != "" {
-			name = containerName
+			name = strings.TrimPrefix(containerName, "/")
 			break
 		}
 	}


### PR DESCRIPTION
In some cases, I need to restart other containers after deunhealth restarts the one with the `deunhealth.restart.on.unhealthy` label.

In order to do this, I added a new label `deunhealth.restart.with.unhealthy.container` which should be applied on containers which must be restarted after deunhealth restarts a monitored one. The value of the label should refer to a deunhealth monitored container. 

Ex:

Container_1 has the label `deunhealth.restart.on.unhealthy=true`
Container_2 has the label `deunhealth.restart.with.unhealthy.container=Container_1`

When Container_1 gets unhealthy, deunhealth will restart it, and will restart Container_2 afterward:

```
2023-03-10T15:23:03-05:00 INFO Monitoring containers Container_1 to restart when becoming unhealthy
2023-03-10T15:23:03-05:00 INFO container Container_1 (image alpine:3.15) is unhealthy, restarting it...
2023-03-10T15:23:04-05:00 INFO container Container_1 restarted successfully
2023-03-10T15:23:04-05:00 INFO container Container_2 (image alpine:3.15) is linked to unhealthy container Container_1, restarting it...
2023-03-10T15:23:04-05:00 INFO linked container Container_2 restarted successfully
```
