### PR TITLE
Fix API version number bug

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -9,7 +9,7 @@ type Docker struct {
 }
 
 func New(dockerHost string) (d *Docker, err error) {
-	client, err := client.NewClientWithOpts(client.WithHost(dockerHost))
+	client, err := client.NewClientWithOpts(client.WithHost(dockerHost), client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes bugs that containers were not watched by changing the docker API version number from 1.42 to 1.44 so that deunhealth detects containers again and outputs to logs correctly again

@qdm12 Please review and make any appropriate changes 

Should fix: 
https://github.com/qdm12/deunhealth/issues/90
https://github.com/qdm12/deunhealth/issues/89

